### PR TITLE
ADD msvc_package_params for extra options on vs install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+.idea
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,8 @@ msvc2015_choco_package:
   - visualstudio2015community
   # - microsoft-visual-cpp-build-tools
 
+msvc_package_params: ""
+
 uninstall_choco_packages:
   - vim
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
   win_chocolatey:
     name: "{{ msvc2015_choco_package }}"
     force: true
-    package_params: '--AdminFile {{ win_local_dir }}/AdminDeployment.xml'
+    package_params: '--AdminFile {{ win_local_dir }}/AdminDeployment.xml {{ msvc_package_params }}'
     timeout: 7200
 
 - name: Install .NET Framework Core
@@ -77,6 +77,7 @@
   poll: 30
   win_chocolatey:
     name: "{{ choco_packages }}"
+    package_params: "{{ msvc_package_params }}"
     force: true
     timeout: 7200
 


### PR DESCRIPTION
Hello again Bas,

I have a workload where I need to add specify some extra components of VS2019 to install. This PR includes the changes so that we can specify those options via a new variable `msvc_package_params` (which is empty by default).

This is specifically so we can specify any of the stuff on this page to run when installing. For me, I need the vs2015 and vs2017 build tools to build for those targets from vs2019. https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?view=vs-2019