### PR TITLE
FIX ansible list fact

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,6 @@
 
 #  https://github.com/ansible/ansible/issues/53971
 - name: Downgrade chocolatey
-  when: not vscode.stat.exists|bool
   win_shell: |
     choco.exe install -y --version 0.10.11 --allow-downgrade chocolatey
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,10 +81,11 @@
   async: 28800
   poll: 30
   win_chocolatey:
-    name: "{{ choco_packages }}"
+    name: "{{ item }}"
     package_params: "{{ msvc_package_params }}"
     force: true
     timeout: 7200
+  with_items: "{{ choco_packages }}"
 
 - name: Install win_buildtools_choco packages
   async: 7200

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,12 @@
   delay: 5
 
 #  https://github.com/ansible/ansible/issues/53971
+- name: Downgrade chocolatey
+  when: not vscode.stat.exists|bool
+  win_shell: |
+    choco.exe install -y --version 0.10.11 --allow-downgrade chocolatey
+
+#  https://github.com/ansible/ansible/issues/53971
 - name: disable win_chocolatey_feature useEnhancedExitCodes
   win_chocolatey_feature:
     name: useEnhancedExitCodes


### PR DESCRIPTION
This is something strange that came up after upgrading ansible. I believe that setting the package fact with a list, then using that fact as a list later on doesnt work in recent ansible versions.

In this error, it looks like it is trying to insert both items in the list as a single package name. 

```text
TASK [win_buildtools : Install VS2017, VS2019 or VS2022] ***********************
task path: /home/jc/vola/git/infra/volainfra/images/windows/roles/win_buildtools/tasks/main.yml:79
redirecting (type: modules) ansible.builtin.win_chocolatey to chocolatey.chocolatey.win_chocolatey
redirecting (type: modules) ansible.builtin.win_chocolatey to chocolatey.chocolatey.win_chocolatey
Using module file /opt/conda/envs/py310_64/lib/python3.10/site-packages/ansible_collections/chocolatey/chocolatey/plugins/modules/win_chocolatey.ps1
Pipelining is enabled.
<127.0.0.1> ESTABLISH WINRM CONNECTION FOR USER: vagrant on PORT 45986 TO 127.0.0.1
EXEC (via pipeline wrapper)
Using module file /opt/conda/envs/py310_64/lib/python3.10/site-packages/ansible_collections/ansible/windows/plugins/modules/async_status.ps1
Pipelining is enabled.
EXEC (via pipeline wrapper)
Using module file /opt/conda/envs/py310_64/lib/python3.10/site-packages/ansible_collections/ansible/windows/plugins/modules/async_status.ps1
Pipelining is enabled.
EXEC (via pipeline wrapper)
ASYNC FAILED on vagrantwindows: jid=j836352172828.5116
fatal: [vagrantwindows]: FAILED! => {
    "ansible_async_watchdog_pid": 3028,
    "ansible_job_id": "j836352172828.5116",
    "changed": false,
    "choco_cli_version": "0.10.11",
    "command": "C:\\ProgramData\\chocolatey\\bin\\choco.exe install \"visualstudio2022community visualstudio2022-workload-vctools\" --fail-on-unfound --yes --no-progress --verbose --force --package-parameters \"--add Microsoft.VisualStudio.Component.VC.140 --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Component.Roslyn.Compiler --add Microsoft.Net.ComponentGroup.4.8.1.DeveloperTools --add Microsoft.Net.Component.4.8.1.TargetingPack --add Microsoft.Net.Component.4.8.1.SDK --add Microsoft.Net.ComponentGroup.4.8.DeveloperTools --add Microsoft.Net.Component.4.8.TargetingPack --add Microsoft.Net.Component.4.8.SDK --add Microsoft.Net.ComponentGroup.4.7.2.DeveloperTools --add Microsoft.Net.Component.4.7.2.TargetingPack --add Microsoft.Net.Component.4.7.2.SDK --add Microsoft.Net.ComponentGroup.4.7.1.DeveloperTools --add Microsoft.Net.Component.4.7.1.TargetingPack --add Microsoft.Net.Component.4.7.1.SDK --add Microsoft.Net.ComponentGroup.4.6.2.DeveloperTools --add Microsoft.Net.Component.4.6.2.TargetingPack --add Microsoft.Net.Component.4.6.2.SDK --add Microsoft.VisualStudio.Component.Windows10SDK.18362 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.Windows10SDK.20348 --add Microsoft.VisualStudio.Component.NuGet --add Microsoft.VisualStudio.Component.NuGet.BuildTools\n\" --timeout 7200",
    "finished": 1,
    "invocation": {
        "module_args": {
            "allow_empty_checksums": false,
            "allow_multiple": false,
            "allow_prerelease": false,
            "architecture": "default",
            "bootstrap_script": null,
            "bootstrap_tls_version": [
                "tls12",
                "tls13"
            ],
            "checksum": null,
            "checksum64": null,
            "checksum_type": null,
            "checksum_type64": null,
            "choco_args": null,
            "force": true,
            "ignore_checksums": false,
            "ignore_dependencies": false,
            "install_args": null,
            "name": [
                "visualstudio2022community",
                "visualstudio2022-workload-vctools"
            ],
            "override_args": false,
            "package_params": "--add Microsoft.VisualStudio.Component.VC.140 --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --add Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Component.Roslyn.Compiler --add Microsoft.Net.ComponentGroup.4.8.1.DeveloperTools --add Microsoft.Net.Component.4.8.1.TargetingPack --add Microsoft.Net.Component.4.8.1.SDK --add Microsoft.Net.ComponentGroup.4.8.DeveloperTools --add Microsoft.Net.Component.4.8.TargetingPack --add Microsoft.Net.Component.4.8.SDK --add Microsoft.Net.ComponentGroup.4.7.2.DeveloperTools --add Microsoft.Net.Component.4.7.2.TargetingPack --add Microsoft.Net.Component.4.7.2.SDK --add Microsoft.Net.ComponentGroup.4.7.1.DeveloperTools --add Microsoft.Net.Component.4.7.1.TargetingPack --add Microsoft.Net.Component.4.7.1.SDK --add Microsoft.Net.ComponentGroup.4.6.2.DeveloperTools --add Microsoft.Net.Component.4.6.2.TargetingPack --add Microsoft.Net.Component.4.6.2.SDK --add Microsoft.VisualStudio.Component.Windows10SDK.18362 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.Windows10SDK.20348 --add Microsoft.VisualStudio.Component.NuGet --add Microsoft.VisualStudio.Component.NuGet.BuildTools\n",
            "pinned": null,
            "proxy_password": null,
            "proxy_url": null,
            "proxy_username": null,
            "remove_dependencies": false,
            "skip_scripts": false,
            "source": null,
            "source_password": null,
            "source_username": null,
            "state": "present",
            "timeout": 7200,
            "validate_certs": true,
            "version": null
        }
    },
    "msg": "Error installing package(s) 'visualstudio2022community visualstudio2022-workload-vctools'",
    "rc": 1,
    "results_file": "C:\\Users\\vagrant\\.ansible_async\\j836352172828.5116",
    "started": 1,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Chocolatey v0.10.11\r\nInstalling the following packages:\r\nvisualstudio2022community visualstudio2022-workload-vctools\r\nBy installing you accept licenses for the packages.\r\nvisualstudio2022community visualstudio2022-workload-vctools not installed. The package was not found with the source(s) listed.\r\n Source(s): 'https://community.chocolatey.org/api/v2/'\r\n NOTE: When you specify explicit sources, it overrides default sources.\r\nIf the package version is a prerelease and you didn't specify `--pre`,\r\n the package may not be found.\r\nPlease see https://chocolatey.org/docs/troubleshooting for more \r\n assistance.\r\n\r\nChocolatey installed 0/1 packages. 1 packages failed.\r\n See the log for details (C:\\ProgramData\\chocolatey\\logs\\chocolatey.log).\r\n\r\nFailures\r\n - visualstudio2022community visualstudio2022-workload-vctools - visualstudio2022community visualstudio2022-workload-vctools not installed. The package was not found with the source(s) listed.\r\n Source(s): 'https://community.chocolatey.org/api/v2/'\r\n NOTE: When you specify explicit sources, it overrides default sources.\r\nIf the package version is a prerelease and you didn't specify `--pre`,\r\n the package may not be found.\r\nPlease see https://chocolatey.org/docs/troubleshooting for more \r\n assistance.\r\n\r\nEnjoy using Chocolatey? Explore more amazing features to take your\r\nexperience to the next level at\r\n https://chocolatey.org/compare\r\n",
    "stdout_lines": [
        "Chocolatey v0.10.11",
        "Installing the following packages:",
        "visualstudio2022community visualstudio2022-workload-vctools",
        "By installing you accept licenses for the packages.",
        "visualstudio2022community visualstudio2022-workload-vctools not installed. The package was not found with the source(s) listed.",
        " Source(s): 'https://community.chocolatey.org/api/v2/'",
        " NOTE: When you specify explicit sources, it overrides default sources.",
        "If the package version is a prerelease and you didn't specify `--pre`,",
        " the package may not be found.",
        "Please see https://chocolatey.org/docs/troubleshooting for more ",
        " assistance.",
        "",
        "Chocolatey installed 0/1 packages. 1 packages failed.",
        " See the log for details (C:\\ProgramData\\chocolatey\\logs\\chocolatey.log).",
        "",
        "Failures",
        " - visualstudio2022community visualstudio2022-workload-vctools - visualstudio2022community visualstudio2022-workload-vctools not installed. The package was not found with the source(s) listed.",
        " Source(s): 'https://community.chocolatey.org/api/v2/'",
        " NOTE: When you specify explicit sources, it overrides default sources.",
        "If the package version is a prerelease and you didn't specify `--pre`,",
        " the package may not be found.",
        "Please see https://chocolatey.org/docs/troubleshooting for more ",
        " assistance.",
        "",
        "Enjoy using Chocolatey? Explore more amazing features to take your",
        "experience to the next level at",
        " https://chocolatey.org/compare"
    ]
}
```

In this PR, I just use a with_item, and it goes through.